### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/app/src/main/java/com/zedeff/twittererer/utils/TimelineConverter.java
+++ b/app/src/main/java/com/zedeff/twittererer/utils/TimelineConverter.java
@@ -15,9 +15,11 @@ import org.joda.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 
-public class TimelineConverter {
+public final class TimelineConverter {
 
     public static final String DATE_TIME_FORMAT = "EEE MMM dd HH:mm:ss Z yyyy";
+
+    private TimelineConverter() {}
 
     public static List<TimelineItem> fromTweets(List<Tweet> tweets, DateTime now) {
         List<TimelineItem> timelineItems = new ArrayList<>();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - Utility classes should not have public constructors

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118

Please let me know if you have any questions.

M-Ezzat
